### PR TITLE
standardise Commander exports usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The `@basd/cli` module is designed to be intuitive for developers familiar with 
 
 The `commander` module in `@basd/cli` is used for building command-line interfaces with support for commands, options, and sub-commands.
 
+Keeping inline with Commander's own recommendations for [declaring the `program` variable](https://github.com/tj/commander.js/tree/v11.1.0?tab=readme-ov-file#declaring-program-variable), this presents two ways to create an instance:
+
+For simpler CLI applications, where everything fits easily in one file:
+
 ```js
 const { program } = require('@basd/cli')
 
@@ -52,6 +56,41 @@ program
 
 // Parse command-line arguments
 program.parse(process.argv)
+```
+
+For more complex application, where you have the need to spread logic out across multiple files:
+
+```js
+// main.js
+const { Command } = require('@basd/cli')
+const program = new Command()
+
+// Attach subcommand
+const { addServeCommand } = require("./serve")
+addServeCommand(program);
+
+// Parse command-line arguments
+program.parse(process.argv)
+```
+
+```js
+// serve.js
+function addServeCommand(program) {
+  // Define a new command with options
+  return program
+    .command('serve [port]')
+    .description('Start the server')
+    .option('-d, --debug', 'output extra debugging')
+    .action((port, options) => {
+      const portNumber = port || 3000
+      console.log(`Server running on port ${portNumber}`)
+      if (options.debug) console.log('Debugging mode is on')
+    })
+}
+
+module.exports = {
+    addServeCommand
+}
 ```
 
 ### ShellJS

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,7 @@ const colors = require('cli-color')
  * @link https://npmjs.com/package/commander
  * @type {Object}
  */
-const Commander = require('commander')
+const { program, Command } = require('commander')
 
 
 /**
@@ -53,8 +53,8 @@ const { Spinner, spinner, Progress } = require('@basd/spinner')
 // Module Augmentation
 
 // Assigning imported modules to the cli object for unified export.
-cli.Commander = Commander
-cli.program = Commander.program // Export Commander.js singleton instance
+cli.Command = Command
+cli.program = program
 cli.Progress = Progress
 cli.Spinner = Spinner
 cli.spinner = spinner


### PR DESCRIPTION
NOTE: I know this is still in "major version zero" days here, but I just couldn't resist.. technically this does impose an "API breaking change", simply because it removes the `Commander` export from `lib/main.js`.

with that said, as per [Commander.js's own exports](https://github.com/tj/commander.js/blob/v11.1.0/index.js#L11-L12), `cli.Commander` and `cli.program` were actually the same thing anyway.

at the same time, this commit introduces access to the `Command` class exported by Commander.js, which makes it much easier to split up Command app logic into different files. readme updated with an example to match.

@basedwon do you have any problem with this..? not sure if you have any particular preference regarding the structure of the example, that's just how I would have written that snippet.